### PR TITLE
Fix broken link in MLT section

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Basic idea: combine eye->light tracing and light->eye tracing to increase conver
 MCMC sampling for light paths.
 
 - [Metropolis light transport](https://graphics.stanford.edu/papers/metro/metro.pdf) Veach & Guibas. SIGGRAPH 1997.
-- [Mitsuba Renderer](www.mitsuba-renderer.org) MLT is notoriously difficult to implement.
+- [Mitsuba Renderer](http://www.mitsuba-renderer.org) MLT is notoriously difficult to implement.
 - [Peter Kutz's BPT+MLT Blog](http://bptmlt.blogspot.com/)
 
 <a name="radiosity" />


### PR DESCRIPTION
Great list of resources. Thanks! A link in the MLT section started with `www` instead of `http://` which breaks it in the readme.